### PR TITLE
Pinned swig to 0.14.0 because of breaking change in swig

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "express": "3.0.5",
-    "swig": "*",
+    "swig": "0.14.0",
     "consolidate": "*",
     "redis": "*",
     "connect-redis": "*",


### PR DESCRIPTION
Only a couple of hours ago paularmstrong released a new version of swig, one that no longer have init(). This causes airfield to fail. Pinning swig to 0.14.0 in the package.json prevents this error from happening.

See
https://github.com/paularmstrong/swig/releases
